### PR TITLE
APIGOV-15499: Improve post-install help text, correct documentation

### DIFF
--- a/apigee/apigee-extension/postinstall.js
+++ b/apigee/apigee-extension/postinstall.js
@@ -24,5 +24,5 @@ const info = (header, example) => {
 };
 info(
 	'Extension Installed: You may now add it to the Central CLI\n',
-	`$ amplify central config set extensions.apigee .${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-apigee-extension`
+	`$ amplify central config set extensions.apigee-extension ${process.cwd()}${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-apigee-extension`
 );

--- a/azure/AzureToUnifiedCatalogIntegration.md
+++ b/azure/AzureToUnifiedCatalogIntegration.md
@@ -111,7 +111,7 @@ Save the **clientId** and **clientSecret** from the response which will be used 
 ### Step 2: Create a Service Principal in Azure API Management using the CLI
 ***
 
-This will be used to authenticate to Azure API Managemement. 
+This will be used to authenticate to Azure API Management. 
 
 1. Install the CLI: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest. 
 2. After you install the CLI, run `az login` command. You will be redirected to login with to your Azure account. 
@@ -708,8 +708,14 @@ You can then install the @axway/amplify-central-azure-extension:
 
 ```powershell
 npm install @axway/amplify-central-azure-extension
-amplify central config set extensions.azure-extension <path to where you installed module>
 ```
+
+The installation would present the command to add this extension to the AMPLIFY Central CLI following this template:
+
+```powershell
+amplify central config set extensions.azure-extension <path to where you installed the extension>
+```
+
 To verify if the CLI extension was successfully set, you can run: `amplify central azure-extension config -h`.
 
 **2. Configure extension**
@@ -738,11 +744,6 @@ Example: `amplify central azure-extension config set --environment-name=azure-en
 * Set the image for the environment
 ```powershell
 amplify central azure-extension config set --icon=<path_to_your_image>
-```
-
-* Set to publish your Azure assets to the Unified Catalog. By default, it is set to `false`. 
-```powershell
-amplify central azure-extension config set --generate-consumer-instances=true
 ```
 
 * Set the filtering option. Only APIs with this tag will be fetched from Azure. if there is no filter set, then all the apis will be fetched. 

--- a/azure/azure-extension/postinstall.js
+++ b/azure/azure-extension/postinstall.js
@@ -24,5 +24,5 @@ const info = (header, example) => {
 };
 info(
 	'Extension Installed: You may now add it to the Central CLI\n',
-	`$ amplify central config set extensions.azure .${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-azure-extension`
+	`$ amplify central config set extensions.azure-extension ${process.cwd()}${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-azure-extension`
 );

--- a/github/github-extension/postinstall.js
+++ b/github/github-extension/postinstall.js
@@ -24,5 +24,5 @@ const info = (header, example) => {
 };
 info(
 	'Extension Installed: You may now add it to the Central CLI\n',
-	`$ amplify central config set extensions.github .${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-github-extension`
+	`$ amplify central config set extensions.github-extension ${process.cwd()}${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-github-extension`
 );

--- a/mulesoft/MulesoftIntegtration.md
+++ b/mulesoft/MulesoftIntegtration.md
@@ -671,7 +671,12 @@ You can then install the @axway/amplify-central-mulesoft-extension:
 
 ```powershell
 npm install @axway/amplify-central-mulesoft-extension
-amplify central config set extensions.mulesoft-extension <path to where you installed module>
+```
+
+The installation would present the command to add this extension to the AMPLIFY Central CLI following this template:
+
+```powershell
+amplify central config set extensions.mulesoft-extension <path to where you installed the extension>
 ```
 
 To verify if the CLI extension was successfully set, you can run: `amplify central mulesoft-extension config -h`.

--- a/mulesoft/mulesoft-extension/postinstall.js
+++ b/mulesoft/mulesoft-extension/postinstall.js
@@ -24,5 +24,5 @@ const info = (header, example) => {
 };
 info(
 	'Extension Installed: You may now add it to the Central CLI\n',
-	`$ amplify central config set extensions.mulesoft .${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-mulesoft-extension`
+	`$ amplify central config set extensions.mulesoft-extension ${process.cwd()}${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-mulesoft-extension`
 );

--- a/swaggerhub/swaggerhub-extension/postinstall.js
+++ b/swaggerhub/swaggerhub-extension/postinstall.js
@@ -24,5 +24,5 @@ const info = (header, example) => {
 };
 info(
 	'Extension Installed: You may now add it to the Central CLI\n',
-	`$ amplify central config set extensions.swaggerhub .${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-swaggerhub-extension`
+	`$ amplify central config set extensions.swaggerhub-extension ${process.cwd()}${path.sep}node_modules${path.sep}@axway${path.sep}amplify-central-swaggerhub-extension`
 );


### PR DESCRIPTION
- Improved post-install help text to include the `full` path
- Corrected documentation to use the post-install help text to configure extensions
- Removed not-implemented `generate-consumer-instances` flag from documentation
- Fix typo