### PR TITLE
APIGOV-20804: Fix build script

### DIFF
--- a/bitbucket/bitbucket-extension/package.json
+++ b/bitbucket/bitbucket-extension/package.json
@@ -9,7 +9,7 @@
     "url": "https://axway.com"
   },
   "scripts": {
-    "build": "yarn tsc && yarn copy:assets",
+    "build": "npm run tsc && npm run copy:assets",
     "copy:assets": "npx cpx 'src/assets/**' 'dist/src/assets'",
     "test": "ts-mocha --timeout 10000",
     "test:coverage": "nyc yarn test",

--- a/layer7/layer7-extension/package.json
+++ b/layer7/layer7-extension/package.json
@@ -9,7 +9,7 @@
     "url": "https://axway.com"
   },
   "scripts": {
-    "build": "yarn tsc && yarn copy:assets",
+    "build": "npm run tsc && npm run copy:assets",
     "copy:assets": "npx cpx 'src/assets/**' 'dist/src/assets'",
     "test": "ts-mocha --timeout 10000",
     "test:coverage": "nyc yarn test",


### PR DESCRIPTION
Some of the build scripts were using yarn. We don't want to depend on that. 